### PR TITLE
fix(core): made R6StatAPI an constructor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ import { GetTransactionsPending } from './methods/getPendingTransactions';
 import { GetTransactionHistroy } from './methods/getTransactionHistory';
 
 export class R6StatAPI {
+  constructor() {
+  }
   public async login(email: string, password: string): Promise<string> {
     return await Auth(email, password);
   }


### PR DESCRIPTION
fixed the issue I wrote you on discord. For some reason it isn't a constructor. Also I would ask if you would be fine to switch to bun for development, because then I could open a pr wich would set the bundlesize to 425kb 